### PR TITLE
Call roc format

### DIFF
--- a/src/Layout.roc
+++ b/src/Layout.roc
@@ -1,7 +1,7 @@
 module [layout]
 
-import html.Html exposing [element, header, table, thead, form, tbody, h1, h5, td, th, tr, nav, meta, span, link, body, button, a, input, div, text, ul, li, label]
-import html.Attribute exposing [attribute, src, id, href, rel, name, integrity, crossorigin, action, method, class, value, role, for, width, height]
+import html.Html exposing [element, header,form, nav, meta, span, link, body, button, a, div, text, ul, li]
+import html.Attribute exposing [attribute, src, id, href, rel, name, integrity, crossorigin, class, width, height]
 import Model exposing [Session]
 import NavLinks exposing [NavLink]
 

--- a/src/Layout.roc
+++ b/src/Layout.roc
@@ -1,39 +1,42 @@
-interface Layout
-    exposes [layout]
-    imports [
-        html.Html.{ element, header, table, thead, form, tbody, h1, h5, td, th, tr, nav, meta, span, link, body, button, a, input, div, text, ul, li, label },
-        html.Attribute.{ attribute, src, id, href, rel, name, integrity, crossorigin, action, method, class, value, role, for, width, height },
-        Model.{Session},
-        NavLinks.{NavLink},
-    ]
+module [layout]
 
-layout : {session : Session, description: Str, title: Str, navLinks : List NavLink}, List Html.Node -> Html.Node
-layout = \{session, description, title, navLinks}, children ->
+import html.Html exposing [element, header, table, thead, form, tbody, h1, h5, td, th, tr, nav, meta, span, link, body, button, a, input, div, text, ul, li, label]
+import html.Attribute exposing [attribute, src, id, href, rel, name, integrity, crossorigin, action, method, class, value, role, for, width, height]
+import Model exposing [Session]
+import NavLinks exposing [NavLink]
 
-    loginOrUser = 
-        when session.user is 
-            Guest -> 
+layout : { session : Session, description : Str, title : Str, navLinks : List NavLink }, List Html.Node -> Html.Node
+layout = \{ session, description, title, navLinks }, children ->
+
+    loginOrUser =
+        when session.user is
+            Guest ->
                 form [class "d-flex"] [
-                    button [
-                        class "btn btn-secondary", 
-                        (attribute "hx-get") "/login", 
-                        (attribute "hx-target") "body", 
-                        (attribute "hx-push-url") "true",
-                    ] [ text "Login"]
+                    button
+                        [
+                            class "btn btn-secondary",
+                            (attribute "hx-get") "/login",
+                            (attribute "hx-target") "body",
+                            (attribute "hx-push-url") "true",
+                        ]
+                        [text "Login"],
                 ]
-            LoggedIn username -> 
+
+            LoggedIn username ->
                 div [class "d-flex"] [
                     span [class "align-self-center d-none d-sm-block"] [personIcon],
                     span [class "align-self-center d-none d-sm-block me-3"] [text username],
-                    button [
-                        class "btn btn-secondary", 
-                        (attribute "hx-post") "/logout", 
-                        (attribute "hx-target") "body", 
-                        (attribute "hx-push-url") "true",
-                    ] [text "Logout"],
+                    button
+                        [
+                            class "btn btn-secondary",
+                            (attribute "hx-post") "/logout",
+                            (attribute "hx-target") "body",
+                            (attribute "hx-push-url") "true",
+                        ]
+                        [text "Logout"],
                 ]
 
-    Html.html [(attribute "lang") "en",  (attribute "data-bs-theme") "auto"] [
+    Html.html [(attribute "lang") "en", (attribute "data-bs-theme") "auto"] [
         Html.head [] [
             (element "title") [] [text title],
             meta [(attribute "charset") "UTF-8"],
@@ -50,71 +53,87 @@ layout = \{session, description, title, navLinks}, children ->
                 href "/styles.css",
             ],
             # The scripts are here to prevent these being loaded each time htmx swaps content of the body
-            (element "script") [
-                src "https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js",
-                integrity "sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL",
-                crossorigin "anonymous",
-            ] [],
-            (element "script") [
-                src "https://unpkg.com/htmx.org@1.9.9",
-                integrity "sha384-QFjmbokDn2DjBjq+fM+8LUIVrAgqcNW2s0PjAxHETgRn9l4fvX31ZxDxvwQnyMOX",
-                crossorigin "anonymous",
-            ] [],
-            (element "script") [
-                src "/site.js",
-            ] [],
+            (element "script")
+                [
+                    src "https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js",
+                    integrity "sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL",
+                    crossorigin "anonymous",
+                ]
+                [],
+            (element "script")
+                [
+                    src "https://unpkg.com/htmx.org@1.9.9",
+                    integrity "sha384-QFjmbokDn2DjBjq+fM+8LUIVrAgqcNW2s0PjAxHETgRn9l4fvX31ZxDxvwQnyMOX",
+                    crossorigin "anonymous",
+                ]
+                [],
+            (element "script")
+                [
+                    src "/site.js",
+                ]
+                [],
         ],
         body [(attribute "hx-boost") "true"] [
             header [] [
                 nav [class "navbar navbar-expand-sm mb-5"] [
                     div [class "container-fluid"] [
-                        
-                        button [
-                            class "navbar-toggler",
-                            (attribute "type") "button",
-                            (attribute "data-bs-toggle") "collapse",
-                            (attribute "data-bs-target") "#navbarNav",
-                            (attribute "aria-controls") "navbarNav",
-                            (attribute "aria-expanded") "false",
-                            (attribute "aria-label") "Toggle navigation",
-                        ][
-                            span [class "navbar-toggler-icon"] []
-                        ],
+                        button
+                            [
+                                class "navbar-toggler",
+                                (attribute "type") "button",
+                                (attribute "data-bs-toggle") "collapse",
+                                (attribute "data-bs-target") "#navbarNav",
+                                (attribute "aria-controls") "navbarNav",
+                                (attribute "aria-expanded") "false",
+                                (attribute "aria-label") "Toggle navigation",
+                            ]
+                            [
+                                span [class "navbar-toggler-icon"] [],
+                            ],
                         div [class "collapse navbar-collapse", id "navbarNav"] [
                             a [class "navbar-brand", href "/"] [text "Roc+HTMX"],
-                            ul [class "navbar-nav me-auto"] (
-                                List.map navLinks \curr ->
-                                    li [class "nav-item"] [
-                                        when curr is 
-                                            Active config ->
-                                                a [
-                                                    class "nav-link active", 
-                                                    (attribute "aria-current") "page", 
-                                                    href config.href,
-                                                    (attribute "hx-push-url") "true",
-                                                ] [text config.label] 
-                                            Inactive config ->
-                                                a [
-                                                    class "nav-link", 
-                                                    href config.href,
-                                                    (attribute "hx-push-url") "true",
-                                                ]  [text config.label]
-                                    ]
-                            ),
+                            ul
+                                [class "navbar-nav me-auto"]
+                                (
+                                    List.map navLinks \curr ->
+                                        li [class "nav-item"] [
+                                            (when curr is
+                                                Active config ->
+                                                    a
+                                                        [
+                                                            class "nav-link active",
+                                                            (attribute "aria-current") "page",
+                                                            href config.href,
+                                                            (attribute "hx-push-url") "true",
+                                                        ]
+                                                        [text config.label]
+
+                                                Inactive config ->
+                                                    a
+                                                        [
+                                                            class "nav-link",
+                                                            href config.href,
+                                                            (attribute "hx-push-url") "true",
+                                                        ]
+                                                        [text config.label]),
+                                        ]
+                                ),
                             loginOrUser,
                         ],
                     ],
                 ],
             ],
-            (element "main") [] children, 
+            (element "main") [] children,
         ],
     ]
 
-personIcon = 
-    Html.svg [
-        (attribute "xmlns") "http://www.w3.org/2000/svg",
-        width "16",
-        height "16",
-        class "me-2",
-        (attribute "viewBox") "0 0 16 16",
-    ][(element "path") [(attribute "d") "M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6m2-3a2 2 0 1 1-4 0 2 2 0 0 1 4 0m4 8c0 1-1 1-1 1H3s-1 0-1-1 1-4 6-4 6 3 6 4m-1-.004c-.001-.246-.154-.986-.832-1.664C11.516 10.68 10.289 10 8 10c-2.29 0-3.516.68-4.168 1.332-.678.678-.83 1.418-.832 1.664z"] []]
+personIcon =
+    Html.svg
+        [
+            (attribute "xmlns") "http://www.w3.org/2000/svg",
+            width "16",
+            height "16",
+            class "me-2",
+            (attribute "viewBox") "0 0 16 16",
+        ]
+        [(element "path") [(attribute "d") "M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6m2-3a2 2 0 1 1-4 0 2 2 0 0 1 4 0m4 8c0 1-1 1-1 1H3s-1 0-1-1 1-4 6-4 6 3 6 4m-1-.004c-.001-.246-.154-.986-.832-1.664C11.516 10.68 10.289 10 8 10c-2.29 0-3.516.68-4.168 1.332-.678.678-.83 1.418-.832 1.664z"] []]

--- a/src/Model.roc
+++ b/src/Model.roc
@@ -1,14 +1,12 @@
-interface Model
-    exposes [
-        Session,
-        Todo,
-        User,
-        Tree,
-        NestedSet, 
-        emptyTodo,
-        nestedSetToTree,
-    ]
-    imports []
+module [
+    Session,
+    Todo,
+    User,
+    Tree,
+    NestedSet,
+    emptyTodo,
+    nestedSetToTree,
+]
 
 Session : {
     id : I64,
@@ -22,9 +20,9 @@ Todo : {
 }
 
 emptyTodo = {
-    id : 0,
-    task : "",
-    status : "Not Started",
+    id: 0,
+    task: "",
+    status: "Not Started",
 }
 
 User : {
@@ -33,98 +31,91 @@ User : {
     name : Str,
 }
 
-NestedSet a : { value: a, left: I64, right: I64}
+NestedSet a : { value : a, left : I64, right : I64 }
 
 Tree a : [
-    Empty, 
+    Empty,
     Node a (List (Tree a)),
 ]
 
 mapTree : Tree a, (a -> b) -> Tree b
 mapTree = \tree, fn ->
-    when tree is 
-        Empty -> Empty 
+    when tree is
+        Empty -> Empty
         Node a children -> Node (fn a) (List.map children \child -> mapTree child fn)
 
 nestedSetToTree : List (NestedSet a) -> Tree a where a implements Eq
 nestedSetToTree = \nodes ->
-    if List.isEmpty nodes then 
-        Empty 
-    else 
+    if List.isEmpty nodes then
+        Empty
+    else
         sortedNodes = List.sortWith nodes \first, second -> if first.left < second.left then LT else GT
-        
+
         buildTree sortedNodes Empty
         |> mapTree .value
 
 buildTree : List (NestedSet a), Tree (NestedSet a) -> Tree (NestedSet a) where a implements Eq
 buildTree = \nodes, parentTree ->
-    when (nodes, parentTree) is 
+    when (nodes, parentTree) is
         ([], Empty) -> Empty
         ([], Node _ _) -> parentTree
         ([current], Empty) -> Node current []
-        ([current], Node parent _) -> 
-
+        ([current], Node parent _) ->
             isChild = current.left > parent.left && current.left < parent.right
             if isChild then
                 buildTree [] (addChild parentTree current)
-            else 
+            else
                 buildTree [] parentTree
-            
-        ([current, .. as rest], Empty) -> 
-            
+
+        ([current, .. as rest], Empty) ->
             buildTree rest (Node current [])
 
         ([current, .. as rest], Node parent _) ->
-
             isChild = current.left > parent.left && current.left < parent.right
             if isChild then
                 buildTree rest (addChild parentTree current)
-            else 
+            else
                 buildTree rest parentTree
 
-addChild : Tree (NestedSet a), NestedSet a -> (Tree (NestedSet a)) where a implements Eq
+addChild : Tree (NestedSet a), NestedSet a -> Tree (NestedSet a) where a implements Eq
 addChild = \tree, current ->
-    when tree is 
+    when tree is
         Empty -> Empty
         Node parent children ->
-
             isChild = current.left > parent.left && current.left < parent.right
             if isChild then
-
                 updatedChildren = List.map children \child -> addChild child current
 
-                isChildOfChild = updatedChildren != children 
+                isChildOfChild = updatedChildren != children
 
-                if isChildOfChild then 
+                if isChildOfChild then
                     Node parent updatedChildren
                 else
-                    Node parent (List.append children (Node current [])) 
-                
+                    Node parent (List.append children (Node current []))
             else
-                
                 Node parent children
 
-findNestedChildren : List (NestedSet a), (NestedSet a) -> List (NestedSet a)
+findNestedChildren : List (NestedSet a), NestedSet a -> List (NestedSet a)
 findNestedChildren = \values, parent ->
-    values |> List.keepIf \{left} -> left > parent.left && left < parent.right
-            
+    values |> List.keepIf \{ left } -> left > parent.left && left < parent.right
+
 testValues = [
-    {value: "Drinks", left: 1, right: 27},
-    {value: "Coffee", left: 2, right: 3},
-    {value: "Tea", left: 4, right: 20},
-    {value: "Black", left: 5, right: 8},
-    {value: "Green", left: 9, right: 19},
-    {value: "China", left: 10, right: 14},
-    {value: "Africa", left: 15, right: 18},
-    {value: "Milk", left: 21, right: 26},
+    { value: "Drinks", left: 1, right: 27 },
+    { value: "Coffee", left: 2, right: 3 },
+    { value: "Tea", left: 4, right: 20 },
+    { value: "Black", left: 5, right: 8 },
+    { value: "Green", left: 9, right: 19 },
+    { value: "China", left: 10, right: 14 },
+    { value: "Africa", left: 15, right: 18 },
+    { value: "Milk", left: 21, right: 26 },
 ]
 
-expect 
-    findNestedChildren testValues {value: "Green", left: 9, right: 19} 
-    == [{value: "China", left: 10, right: 14}, {value: "Africa", left: 15, right: 18}]
+expect
+    findNestedChildren testValues { value: "Green", left: 9, right: 19 }
+    == [{ value: "China", left: 10, right: 14 }, { value: "Africa", left: 15, right: 18 }]
 
-expect 
-    expected = 
+expect
+    expected =
         Node "Drinks" [
             Node "Coffee" [],
             Node "Tea" [

--- a/src/NavLinks.roc
+++ b/src/NavLinks.roc
@@ -1,6 +1,4 @@
-interface NavLinks
-    exposes [NavLink, navLinks]
-    imports []
+module [NavLink, navLinks]
 
 NavLink : [
     Active { label : Str, href : Str },

--- a/src/Pages/Home.roc
+++ b/src/Pages/Home.roc
@@ -1,22 +1,22 @@
-interface Pages.Home
-    exposes [view]
-    imports [
-        html.Html,
-        html.Attribute,
-        Model.{Session},
-        Layout.{layout},
-        NavLinks,
-    ]
+module [view]
 
-view : {session : Session} -> Html.Node
-view = \{session} ->
-    layout {
-        session, 
-        description: "HOME PAGE", 
-        title: "HOME", 
-        navLinks : NavLinks.navLinks "Home", 
-    } [
-        Html.div [Attribute.class "container"] [
-            Html.h1 [] [Html.text "Home"],
+import html.Html
+import html.Attribute
+import Model exposing [Session]
+import Layout exposing [layout]
+import NavLinks
+
+view : { session : Session } -> Html.Node
+view = \{ session } ->
+    layout
+        {
+            session,
+            description: "HOME PAGE",
+            title: "HOME",
+            navLinks: NavLinks.navLinks "Home",
+        }
+        [
+            Html.div [Attribute.class "container"] [
+                Html.h1 [] [Html.text "Home"],
+            ],
         ]
-    ]

--- a/src/Pages/Login.roc
+++ b/src/Pages/Login.roc
@@ -1,7 +1,7 @@
 module [view]
 
-import html.Html exposing [header, table, thead, form, tbody, h1, h5, td, th, tr, nav, meta, button, span, link, body, a, input, div, text, ul, li, label]
-import html.Attribute exposing [attribute, src, id, href, rel, name, integrity, crossorigin, action, method, class, value, role, for, width, height]
+import html.Html exposing [form, h5,  button, a, input, div, text, label]
+import html.Attribute exposing [attribute, id, href, name, action, method, class,  for]
 import Model exposing [Session]
 import Layout exposing [layout]
 import NavLinks

--- a/src/Pages/Login.roc
+++ b/src/Pages/Login.roc
@@ -1,17 +1,17 @@
-interface Pages.Login
-    exposes [view]
-    imports [
-        html.Html.{ header, table, thead, form, tbody, h1, h5, td, th, tr, nav, meta,  button, span, link, body,  a, input, div, text, ul, li, label },
-        html.Attribute.{ attribute, src, id, href, rel, name, integrity, crossorigin, action, method, class, value, role, for, width, height },
-        Model.{ Session },
-        Layout.{ layout },
-        NavLinks,
-    ]
+module [view]
 
-view : {
-    session : Session,
-    user : [Fresh, UserNotProvided, UserNotFound Str],
-} -> Html.Node
+import html.Html exposing [header, table, thead, form, tbody, h1, h5, td, th, tr, nav, meta, button, span, link, body, a, input, div, text, ul, li, label]
+import html.Attribute exposing [attribute, src, id, href, rel, name, integrity, crossorigin, action, method, class, value, role, for, width, height]
+import Model exposing [Session]
+import Layout exposing [layout]
+import NavLinks
+
+view :
+    {
+        session : Session,
+        user : [Fresh, UserNotProvided, UserNotFound Str],
+    }
+    -> Html.Node
 view = \{ session, user } ->
 
     (usernameInputClass, usernameValidationClass, usernameValidationText) =
@@ -51,8 +51,8 @@ view = \{ session, user } ->
                                     button [(attribute "type") "submit", (attribute "type") "button", class "btn btn-primary"] [text "Submit"],
                                 ],
                                 div [class "col-auto mt-3"] [
-                                    a [href "/register", class "btn btn-outline-primary"] [text "Register"]
-                                ],                                
+                                    a [href "/register", class "btn btn-outline-primary"] [text "Register"],
+                                ],
                             ],
                         ],
                     ],

--- a/src/Pages/Register.roc
+++ b/src/Pages/Register.roc
@@ -1,18 +1,18 @@
-interface Pages.Register
-    exposes [view]
-    imports [
-        html.Html.{ header, table, thead, form, tbody, h1, h5, td, th, tr, nav, meta, span, link, body, button, a, input, div, text, ul, li, label },
-        html.Attribute.{ attribute, src, id, href, rel, name, integrity, crossorigin, action, method, class, value, role, for, width, height },
-        Model.{ Session },
-        Layout.{ layout },
-        NavLinks,
-    ]
+module [view]
 
-view : {
-    session : Session,
-    user : [Fresh, UserAlreadyExists Str, UserNotProvided],
-    email : [Valid, Invalid Str, NotProvided],
-} -> Html.Node
+import html.Html exposing [header, table, thead, form, tbody, h1, h5, td, th, tr, nav, meta, span, link, body, button, a, input, div, text, ul, li, label]
+import html.Attribute exposing [attribute, src, id, href, rel, name, integrity, crossorigin, action, method, class, value, role, for, width, height]
+import Model exposing [Session]
+import Layout exposing [layout]
+import NavLinks
+
+view :
+    {
+        session : Session,
+        user : [Fresh, UserAlreadyExists Str, UserNotProvided],
+        email : [Valid, Invalid Str, NotProvided],
+    }
+    -> Html.Node
 view = \{ session, user, email } ->
 
     (usernameInputClass, usernameValidationClass, usernameValidationText) =

--- a/src/Pages/Register.roc
+++ b/src/Pages/Register.roc
@@ -1,7 +1,7 @@
 module [view]
 
-import html.Html exposing [header, table, thead, form, tbody, h1, h5, td, th, tr, nav, meta, span, link, body, button, a, input, div, text, ul, li, label]
-import html.Attribute exposing [attribute, src, id, href, rel, name, integrity, crossorigin, action, method, class, value, role, for, width, height]
+import html.Html exposing [form, h5, button, input, div, text,  label]
+import html.Attribute exposing [attribute, id, name, action, method, class,  for]
 import Model exposing [Session]
 import Layout exposing [layout]
 import NavLinks

--- a/src/Pages/Todo.roc
+++ b/src/Pages/Todo.roc
@@ -3,8 +3,8 @@ module [
     listTodoView,
 ]
 
-import html.Html exposing [element, header, table, thead, form, tbody, h1, h5, td, th, tr, nav, meta, span, body, button, a, input, div, text, ul, li, label]
-import html.Attribute exposing [attribute, id, href, rel, name, action, method, class, value, role, for, width, height]
+import html.Html exposing [element, table, thead, form, tbody, h1, td, th, tr,  button,  input, div, text, label]
+import html.Attribute exposing [attribute, id,  name, action, method, class, value, role, for]
 import Model exposing [Session, Todo]
 import Layout exposing [layout]
 import NavLinks

--- a/src/Pages/Todo.roc
+++ b/src/Pages/Todo.roc
@@ -1,15 +1,13 @@
-interface Pages.Todo
-    exposes [
-        view,
-        listTodoView,
-    ]
-    imports [
-        html.Html.{ element, header, table, thead, form, tbody, h1, h5, td, th, tr, nav, meta, span, body, button, a, input, div, text, ul, li, label },
-        html.Attribute.{ attribute, id, href, rel, name, action, method, class, value, role, for, width, height },
-        Model.{ Session, Todo },
-        Layout.{ layout },
-        NavLinks,
-    ]
+module [
+    view,
+    listTodoView,
+]
+
+import html.Html exposing [element, header, table, thead, form, tbody, h1, h5, td, th, tr, nav, meta, span, body, button, a, input, div, text, ul, li, label]
+import html.Attribute exposing [attribute, id, href, rel, name, action, method, class, value, role, for, width, height]
+import Model exposing [Session, Todo]
+import Layout exposing [layout]
+import NavLinks
 
 view : { todos : List Todo, filterQuery : Str, session : Session } -> Html.Node
 view = \{ todos, filterQuery, session } ->
@@ -34,20 +32,19 @@ view = \{ todos, filterQuery, session } ->
                     ],
                     div [class "col-md-9"] [
                         createAppTaskView,
-                        input
-                            [
-                                class "form-control mt-2",
-                                name "filterTasks",
-                                (attribute "type") "text",
-                                (attribute "placeholder") "Search",
-                                (attribute "type") "text",
-                                value filterQuery,
-                                name "taskSearch",
-                                (attribute "hx-post") "/task/search",
-                                (attribute "hx-trigger") "input changed delay:500ms, search",
-                                (attribute "hx-target") "#taskTable",
-                                if Str.isEmpty filterQuery then id "nothing" else (attribute "autofocus") "",
-                            ],
+                        input [
+                            class "form-control mt-2",
+                            name "filterTasks",
+                            (attribute "type") "text",
+                            (attribute "placeholder") "Search",
+                            (attribute "type") "text",
+                            value filterQuery,
+                            name "taskSearch",
+                            (attribute "hx-post") "/task/search",
+                            (attribute "hx-trigger") "input changed delay:500ms, search",
+                            (attribute "hx-target") "#taskTable",
+                            if Str.isEmpty filterQuery then id "nothing" else (attribute "autofocus") "",
+                        ],
                         listTodoView { todos, filterQuery },
                     ],
                 ],
@@ -74,7 +71,7 @@ listTodoView = \{ todos, filterQuery } ->
             completeButton =
                 when task.status is
                     "Completed" -> div [] []
-                    _ -> 
+                    _ ->
                         (element "button")
                             completeButtonBaseAttr
                             [text "Complete"]
@@ -120,15 +117,14 @@ createAppTaskView : Html.Node
 createAppTaskView =
     form [action "/task/new", method "post"] [
         div [class "input-group mb-3"] [
-            input
-                [
-                    id "task",
-                    name "task",
-                    (attribute "type") "text",
-                    class "form-control",
-                    (attribute "placeholder") "Describe a new task",
-                    (attribute "required") "",
-                ],
+            input [
+                id "task",
+                name "task",
+                (attribute "type") "text",
+                class "form-control",
+                (attribute "placeholder") "Describe a new task",
+                (attribute "required") "",
+            ],
             label [for "task", class "d-none"] [text "input the task description"],
             input [name "status", value "In-Progress", (attribute "type") "text", class "d-none"], # hidden form input
             button [(attribute "type") "submit", class "btn btn-primary"] [text "Add"],

--- a/src/Pages/TreeView.roc
+++ b/src/Pages/TreeView.roc
@@ -1,17 +1,17 @@
-interface Pages.TreeView
-    exposes [view]
-    imports [
-        html.Html,
-        html.Attribute.{ attribute, class },
-        Model.{ Session, Todo, Tree },
-        Layout.{ layout },
-        NavLinks,
-    ]
+module [view]
 
-view : {
-    session : Session,
-    nodes : Tree Todo,
-} -> Html.Node
+import html.Html
+import html.Attribute exposing [attribute, class]
+import Model exposing [Session, Todo, Tree]
+import Layout exposing [layout]
+import NavLinks
+
+view :
+    {
+        session : Session,
+        nodes : Tree Todo,
+    }
+    -> Html.Node
 view = \{ session, nodes } ->
     layout
         {
@@ -21,21 +21,25 @@ view = \{ session, nodes } ->
             navLinks: NavLinks.navLinks "TreeView",
         }
         [
-            Html.div [
-                class "container",
-                (attribute "hx-get") "/treeview",
-                (attribute "hx-target") "body",
-                (attribute "hx-trigger") "todosUpdated from:body"
-            ] [
-                Html.div [class "row justify-content-center"] [
-                    Html.ul [
-                        class "todo-tree-ul",
-                        
-                    ] [
-                        nodesView nodes 
-                    ]
+            Html.div
+                [
+                    class "container",
+                    (attribute "hx-get") "/treeview",
+                    (attribute "hx-target") "body",
+                    (attribute "hx-trigger") "todosUpdated from:body",
+                ]
+                [
+                    Html.div [class "row justify-content-center"] [
+                        Html.ul
+                            [
+                                class "todo-tree-ul",
+
+                            ]
+                            [
+                                nodesView nodes,
+                            ],
+                    ],
                 ],
-            ],
         ]
 
 nodesView : Tree Todo -> Html.Node
@@ -43,11 +47,10 @@ nodesView = \node ->
     when node is
         Empty -> Html.li [] [Html.text "EMPTY"]
         Node todo children ->
-
-            checkbox = 
+            checkbox =
                 if todo.status == "Completed" then
                     checkboxElem todo.task (Num.toStr todo.id) Checked
-                else 
+                else
                     checkboxElem todo.task (Num.toStr todo.id) NotChecked
 
             Html.li [] [
@@ -56,29 +59,32 @@ nodesView = \node ->
             ]
 
 checkboxElem = \str, taskIdStr, check ->
-    (checkAttrs) = 
-        when check is 
-            Checked -> 
-                ([
+    checkAttrs =
+        when check is
+            Checked ->
+                [
                     (attribute "hx-put") "/task/$(taskIdStr)/in-progress",
                     class "form-check-input",
                     (attribute "type") "checkbox",
                     (attribute "value") "",
                     (attribute "checked") "",
-                ]) 
-            NotChecked -> 
-                ([
+                ]
+
+            NotChecked ->
+                [
                     (attribute "hx-put") "/task/$(taskIdStr)/complete",
                     class "form-check-input",
                     (attribute "type") "checkbox",
                     (attribute "value") "",
-                ])
+                ]
 
     Html.div [class "form-check"] [
         Html.input checkAttrs,
-        Html.label [
-            class "form-check-label",
-        ] [
-            Html.text str
-        ],
+        Html.label
+            [
+                class "form-check-label",
+            ]
+            [
+                Html.text str,
+            ],
     ]

--- a/src/Pages/UserList.roc
+++ b/src/Pages/UserList.roc
@@ -1,14 +1,12 @@
-interface Pages.UserList
-    exposes [
-        view,
-    ]
-    imports [
-        html.Html.{ element, h1, td, th, tr, table, thead, tbody, div, text },
-        html.Attribute.{ class, id },
-        Model.{ User, Session },
-        Layout.{ layout },
-        NavLinks,
-    ]
+module [
+    view,
+]
+
+import html.Html exposing [element, h1, td, th, tr, table, thead, tbody, div, text]
+import html.Attribute exposing [class, id]
+import Model exposing [User, Session]
+import Layout exposing [layout]
+import NavLinks
 
 view : { users : List User, session : Session } -> Html.Node
 view = \{ users, session } ->

--- a/src/Pages/UserList.roc
+++ b/src/Pages/UserList.roc
@@ -2,7 +2,7 @@ module [
     view,
 ]
 
-import html.Html exposing [element, h1, td, th, tr, table, thead, tbody, div, text]
+import html.Html exposing [h1, td, th, tr, table, thead, tbody, div, text]
 import html.Attribute exposing [class, id]
 import Model exposing [User, Session]
 import Layout exposing [layout]

--- a/src/Sql/Session.roc
+++ b/src/Sql/Session.roc
@@ -1,15 +1,13 @@
-interface Sql.Session
-    exposes [
-        new,
-        parse,
-        get,
-    ]
-    imports [
-        pf.Task.{ Task },
-        pf.Http.{ Request },
-        pf.SQLite3,
-        Model.{ Session },
-    ]
+module [
+    new,
+    parse,
+    get,
+]
+
+import pf.Task exposing [Task]
+import pf.Http exposing [Request]
+import pf.SQLite3
+import Model exposing [Session]
 
 new : Str -> Task I64 _
 new = \path ->

--- a/src/Sql/Todo.roc
+++ b/src/Sql/Todo.roc
@@ -1,16 +1,14 @@
-interface Sql.Todo
-    exposes [
-        list,
-        create,
-        delete,
-        update,
-        tree,
-    ]
-    imports [
-        pf.Task.{ Task },
-        pf.SQLite3,
-        Model.{ Todo, Tree, NestedSet },
-    ]
+module [
+    list,
+    create,
+    delete,
+    update,
+    tree,
+]
+
+import pf.Task exposing [Task]
+import pf.SQLite3
+import Model exposing [Todo, Tree, NestedSet]
 
 list : { path : Str, filterQuery : Str } -> Task (List Todo) _
 list = \{ path, filterQuery } ->
@@ -35,8 +33,9 @@ parseListRows : List (List SQLite3.Value), List Todo -> Result (List Todo) _
 parseListRows = \rows, acc ->
     when rows is
         [] -> acc |> Ok
-        [[Integer id, String task, String status], .. as rest] -> 
+        [[Integer id, String task, String status], .. as rest] ->
             parseListRows rest (List.append acc { id, task, status })
+
         _ -> Inspect.toStr rows |> UnexpectedSQLValues |> Err
 
 create : { path : Str, newTodo : Todo } -> Task {} [TodoWasEmpty, SqlError _]_
@@ -119,7 +118,6 @@ parseTreeRows = \rows, acc ->
     when rows is
         [] -> Model.nestedSetToTree acc |> Ok
         [[Integer id, String task, String status, Integer left, Integer right], .. as rest] ->
-
             todo : Todo
             todo = { id, task, status }
 

--- a/src/Sql/User.roc
+++ b/src/Sql/User.roc
@@ -1,15 +1,13 @@
-interface Sql.User
-    exposes [
-        find,
-        login,
-        register,
-        list,
-    ]
-    imports [
-        pf.Task.{ Task },
-        pf.SQLite3,
-        Model.{ User },
-    ]
+module [
+    find,
+    login,
+    register,
+    list,
+]
+
+import pf.Task exposing [Task]
+import pf.SQLite3
+import Model exposing [User]
 
 find : Str, Str -> Task User _
 find = \path, name ->

--- a/src/Sql/User.roc
+++ b/src/Sql/User.roc
@@ -82,7 +82,7 @@ register = \{ path, name, email } ->
             |> Task.mapErr SqlError
             |> Task.map \_ -> {}
 
-        Ok user -> UserAlreadyExists |> Task.err
+        Ok _user -> UserAlreadyExists |> Task.err
         Err err -> Task.err err
 
 list : Str -> Task (List User) _

--- a/src/main.roc
+++ b/src/main.roc
@@ -1,35 +1,32 @@
-app "http"
-    packages {
-        pf: "https://github.com/roc-lang/basic-webserver/releases/download/0.5.0/Vq-iXfrRf-aHxhJpAh71uoVUlC-rsWvmjzTYOJKhu4M.tar.br",
-        html: "https://github.com/Hasnep/roc-html/releases/download/v0.6.0/IOyNfA4U_bCVBihrs95US9Tf5PGAWh3qvrBN4DRbK5c.tar.br",
-        ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.1.1/cPHdNPNh8bjOrlOgfSaGBJDz6VleQwsPdW0LJK6dbGQ.tar.br",
-    }
-    imports [
-        pf.Stdout,
-        pf.Stderr,
-        pf.Task.{ Task },
-        pf.Http.{ Request, Response },
-        pf.Env,
-        pf.Utc,
-        pf.Url.{ Url },
-        pf.SQLite3,
-        html.Html,
-        html.Attribute,
-        ansi.Color,
-        "site.css" as stylesFile : List U8,
-        "site.js" as siteFile : List U8,
-        Sql.Todo,
-        Sql.Session,
-        Sql.User,
-        Model.{ Session, Todo },
-        Pages.Home,
-        Pages.Login,
-        Pages.Register,
-        Pages.Todo,
-        Pages.UserList,
-        Pages.TreeView,
-    ]
-    provides [main] to pf
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-webserver/releases/download/0.5.0/Vq-iXfrRf-aHxhJpAh71uoVUlC-rsWvmjzTYOJKhu4M.tar.br",
+    html: "https://github.com/Hasnep/roc-html/releases/download/v0.6.0/IOyNfA4U_bCVBihrs95US9Tf5PGAWh3qvrBN4DRbK5c.tar.br",
+    ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.1.1/cPHdNPNh8bjOrlOgfSaGBJDz6VleQwsPdW0LJK6dbGQ.tar.br",
+}
+
+import pf.Stdout
+import pf.Stderr
+import pf.Task exposing [Task]
+import pf.Http exposing [Request, Response]
+import pf.Env
+import pf.Utc
+import pf.Url exposing [Url]
+import pf.SQLite3
+import html.Html
+import html.Attribute
+import ansi.Color
+import "site.css" as stylesFile : List U8
+import "site.js" as siteFile : List U8
+import Sql.Todo
+import Sql.Session
+import Sql.User
+import Model exposing [Session, Todo]
+import Pages.Home
+import Pages.Login
+import Pages.Register
+import Pages.Todo
+import Pages.UserList
+import Pages.TreeView
 
 main : Request -> Task Response []
 main = \req ->
@@ -136,7 +133,6 @@ handleReq = \session, dbPath, req ->
                     }
 
         (Get, ["task", "new"]) -> redirect "/task"
-
         (Post, ["task", idStr, "delete"]) ->
             {} <- Sql.Todo.delete { path: dbPath, userId: idStr } |> Task.await
 

--- a/src/main.roc
+++ b/src/main.roc
@@ -10,10 +10,8 @@ import pf.Task exposing [Task]
 import pf.Http exposing [Request, Response]
 import pf.Env
 import pf.Utc
-import pf.Url exposing [Url]
-import pf.SQLite3
+import pf.Url
 import html.Html
-import html.Attribute
 import ansi.Color
 import "site.css" as stylesFile : List U8
 import "site.js" as siteFile : List U8


### PR DESCRIPTION
The changes where created by calling `roc format`.

I only had to manually add parenthesize in `src/Layout.roc` on line 100 and 118.

When you call `roc check`, you get 81 warnings about unused imports. This are mainly unused html attributes or html tags. Would you accept a PR that removes the unused imports or do you want to keep them, so the `import html.Html` lines are the same on each module?